### PR TITLE
Fix spurious disabling of Infineon TPM

### DIFF
--- a/libstb/drivers/tpm_i2c_infineon.c
+++ b/libstb/drivers/tpm_i2c_infineon.c
@@ -78,8 +78,17 @@ static int tpm_status_read_byte(uint8_t offset, uint8_t *byte)
 {
 	int rc = tpm_i2c_request_send(tpm_device, SMBUS_READ, offset, 1, byte,
 				      sizeof(uint8_t));
-	if (rc == 0 && offset == TPM_STS && *byte == 0xff)
-		return STB_DRIVER_ERROR;
+	if (rc == 0 && offset == TPM_STS && *byte == 0xff) {
+		/*
+		 * According to src/drivers/i2c/tpm.c driver in coreboot:
+		 *
+		 *     Some TPMs sometimes randomly return 0xff.
+		 *
+		 * Do not error in this case, just replace result with zero to
+		 * cause another try.
+		 */
+		*byte = 0;
+	}
 	return rc;
 }
 


### PR DESCRIPTION
Sometimes a TPM operation will fail and result in disabling of TPM node in DT:
```
[   25.019674986,5] STB: EV_SEPARATOR measured on pcr6 (tpm0, evType 0x4, evLogLen 1384)
[   25.019896418,3] INFINEON: fail to read sts.commandReady, rc=-3
[   25.019962074,3] TSS: TPM PCRExtend Transmit Fail
[   25.019990469,3] STB: EV_SEPARATOR -> tpm0 FAILED: pcr7 rc=-3
[   25.020025465,5] STB: tpm0 disabled
```

This happens due to TPM returning status of `0xff` which was handled as a fatal error.  Comment at the top says `- discard 0xff status as coreboot does`, so maybe I thought that returning "driver error" was actually skipping it, which is wrong.