### PR TITLE
core: disable fast-reboot

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -1195,6 +1195,8 @@ void __noreturn __nomcount main_cpu_entry(const void *fdt)
 
 	op_display(OP_LOG, OP_MOD_INIT, 0x0002);
 
+	disable_fast_reboot("Interferes with Heads' use of TPM");
+
 	/*
 	 * On some POWER9 BMC systems, we need to initialise the OCC
 	 * before the NPU to facilitate NVLink/OpenCAPI presence


### PR DESCRIPTION
TPM's PCRs are not reset during fast-reboot which interferes with measured boot workflow that requires full reboots.